### PR TITLE
Update array_shift benchmark.

### DIFF
--- a/ruby/benchmarks/bm_array_shift.rb
+++ b/ruby/benchmarks/bm_array_shift.rb
@@ -1,14 +1,11 @@
-require 'benchmark'
+[10_000,1_000_000,100_000_000].each do |n|
+  ary = Array.new(n,0)
+  GC.start
+  ary.shift
 
-Benchmark.bm do |x|
-  [10_000,1_000_000,100_000_000].each do |n|
+  (0..4).each do |i|
     ary = Array.new(n,0)
     GC.start
-    x.report("#{n}:shift"){ ary.shift }
-    (0..4).each do |i|
-      ary = Array.new(n,0)
-      GC.start
-      x.report("#{n}:shift(#{i})"){ ary.shift(i) }
-    end
+    ary.shift(i)
   end
 end


### PR DESCRIPTION
`Benchmark.report` is unnecessary for us.

https://github.com/ruby-bench/ruby-bench-suite/issues/38
