### PR TITLE
Add throw/catch benchmark

### DIFF
--- a/ruby/benchmarks/bm_app_throw.rb
+++ b/ruby/benchmarks/bm_app_throw.rb
@@ -1,0 +1,7 @@
+i = 0
+while i<300000
+  i += 1
+  catch(:ball) do
+    throw(:ball)
+  end
+end


### PR DESCRIPTION
A casual benchmark shows me throw/catch is 2x faster that raise/rescue.
If figure this should be tracked.

https://gist.github.com/bf4/5a576b9a46b4c63a8fe942dbc47aaba8

``` ruby
require 'benchmark/ips'

Benchmark.ips do |x|
  x.report(:raise_rescue) do
    begin
      raise ArgumentError
    rescue ArgumentError
    end
  end

  x.report(:throw_catch) do
    begin
      catch(:halt) do
        throw(:halt)
      end
    end
  end
  x.compare!
end

  # Ruby 2.2.4 on OSX
  # Warming up --------------------------------------
  #         raise_rescue    58.744k i/100ms
  #          throw_catch   157.030k i/100ms
  # Calculating -------------------------------------
  #         raise_rescue    704.836k (± 6.7%) i/s -      3.525M in   5.023761s
  #          throw_catch      2.532M (± 5.3%) i/s -     12.719M in   5.037449s
  #
  # Comparison:
  #          throw_catch:  2532310.2 i/s
  #         raise_rescue:   704835.7 i/s - 3.59x slower
```
