### PR TITLE
Sequel benchmarks for rails

### DIFF
--- a/rails/benchmarks/bm_sequel_destroy.rb
+++ b/rails/benchmarks/bm_sequel_destroy.rb
@@ -1,0 +1,26 @@
+require 'bundler/setup'
+require 'sequel'
+require_relative 'support/benchmark_rails'
+
+DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
+
+DB.create_table(:users) do
+  primary_key :id
+  column :name, "varchar(255)"
+  column :email, "varchar(255)"
+  column :created_at, "timestamp"
+  column :updated_at, "timestamp"
+end
+
+class User < Sequel::Model; end
+
+attributes = {
+  name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+  email: "foobar@email.com"
+}
+
+Benchmark.rails("sequel/#{db_adapter}_destroy", time: 5) do
+  # we need to create the record in order to delete it
+  user = User.create(attributes)
+  user.destroy
+end

--- a/rails/benchmarks/bm_sequel_finders_find_by_attributes.rb
+++ b/rails/benchmarks/bm_sequel_finders_find_by_attributes.rb
@@ -1,0 +1,30 @@
+require 'bundler/setup'
+require 'sequel'
+require_relative 'support/benchmark_rails'
+
+DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
+
+DB.create_table(:users) do
+  primary_key :id
+  column :name, "varchar(255)"
+  column :email, "varchar(255)"
+  column :created_at, "timestamp"
+  column :updated_at, "timestamp"
+end
+
+class User < Sequel::Model; end
+
+attributes = {
+  name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+  email: "foobar@email.com"
+}
+
+1000.times do
+  User.create(attributes)
+end
+
+User.create(name: 'kir', email: 'shatrov@me.com')
+
+Benchmark.rails("sequel/#{db_adapter}_finders_find_by_attributes", time: 5) do
+  User.find(email: 'shatrov@me.com')
+end

--- a/rails/benchmarks/bm_sequel_finders_first.rb
+++ b/rails/benchmarks/bm_sequel_finders_first.rb
@@ -1,0 +1,30 @@
+require 'bundler/setup'
+require 'sequel'
+require_relative 'support/benchmark_rails'
+
+DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
+
+DB.create_table(:users) do
+  primary_key :id
+  column :name, "varchar(255)"
+  column :email, "varchar(255)"
+  column :created_at, "timestamp"
+  column :updated_at, "timestamp"
+end
+
+class User < Sequel::Model; end
+
+attributes = {
+  name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+  email: "foobar@email.com"
+}
+
+1000.times do
+  User.create(attributes)
+end
+
+User.create(name: 'kir', email: 'shatrov@me.com')
+
+Benchmark.rails("sequel/#{db_adapter}_finders_find_by_attributes", time: 5) do
+  User.first
+end

--- a/rails/benchmarks/bm_sequel_save.rb
+++ b/rails/benchmarks/bm_sequel_save.rb
@@ -1,0 +1,27 @@
+require 'bundler/setup'
+require 'sequel'
+require_relative 'support/benchmark_rails'
+
+DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
+
+DB.create_table(:users) do
+  primary_key :id
+  column :name, "varchar(255)"
+  column :email, "varchar(255)"
+  column :created_at, "timestamp"
+  column :updated_at, "timestamp"
+end
+
+class User < Sequel::Model; end
+
+attributes = {
+  name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+  email: "foobar@email.com"
+}
+
+Benchmark.rails("sequel/#{db_adapter}_save", time: 5) do
+  user = User.new(attributes)
+  unless user.save
+    raise "should save correctly"
+  end
+end

--- a/rails/benchmarks/bm_sequel_scope_all.rb
+++ b/rails/benchmarks/bm_sequel_scope_all.rb
@@ -1,0 +1,28 @@
+require 'bundler/setup'
+require 'sequel'
+require_relative 'support/benchmark_rails'
+
+DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
+
+DB.create_table(:users) do
+  primary_key :id
+  column :name, "varchar(255)"
+  column :email, "varchar(255)"
+  column :created_at, "timestamp"
+  column :updated_at, "timestamp"
+end
+
+class User < Sequel::Model; end
+
+attributes = {
+  name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+  email: "foobar@email.com"
+}
+
+1000.times do
+  User.create(attributes)
+end
+
+Benchmark.rails("sequel/#{db_adapter}_scope_all", time: 5) do
+  User.all.to_a
+end

--- a/rails/benchmarks/bm_sequel_scope_where.rb
+++ b/rails/benchmarks/bm_sequel_scope_where.rb
@@ -1,0 +1,29 @@
+require 'bundler/setup'
+require 'sequel'
+require_relative 'support/benchmark_rails'
+
+DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
+
+DB.create_table(:users) do
+  primary_key :id
+  column :name, "varchar(255)"
+  column :email, "varchar(255)"
+  column :created_at, "timestamp"
+  column :updated_at, "timestamp"
+end
+
+DB.add_index :users, :email, :unique => true
+
+class User < Sequel::Model; end
+
+1000.times do |i|
+  User.create({
+    name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+    email: "foobar#{"%03d" % i}@email.com"
+  })
+end
+
+Benchmark.rails("sequel/#{db_adapter}_scope_where", time: 5) do
+  User.where(name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
+      .where(Sequel.ilike(:email, 'foobar00%@email.com')).to_a
+end

--- a/rails/benchmarks/bm_sequel_validations_invalid.rb
+++ b/rails/benchmarks/bm_sequel_validations_invalid.rb
@@ -1,0 +1,43 @@
+require 'bundler/setup'
+require 'sequel'
+require_relative 'support/benchmark_rails'
+
+DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
+
+DB.create_table(:posts) do
+  primary_key :id
+  column :title, "varchar(255)"
+  column :author, "varchar(255)"
+  column :body, "Text"
+  column :sequence, 'integer(11)'
+  column :age, 'integer(11)'
+  column :legacy_code, "varchar(255)"
+  column :size, "varchar(255)"
+end
+
+class Post < Sequel::Model
+  plugin :validation_helpers
+  def validate
+    super
+    validates_presence :title
+    validates_unique :sequence
+    validates_numeric :age, numericality: { greater_than: 18, less_than: 80 }
+    validates_format /\A[a-zA-Z]+\z/, :legacy_code, :message=> "only allows letters"
+    validates_includes %w(small medium large), :size, :message=> "%{value} is not a valid size"
+  end
+end
+
+post = Post.new({
+  title: '',
+  author: '',
+  age: 10,
+  sequence: 90,
+  legacy_code: '32_leg',
+  size: 'overbig'
+})
+
+Benchmark.rails("sequel/#{db_adapter}_validations_invalid", time: 5) do
+  if post.valid?
+    raise "should not be valid"
+  end
+end

--- a/rails/benchmarks/bm_sequel_validations_valid.rb
+++ b/rails/benchmarks/bm_sequel_validations_valid.rb
@@ -1,0 +1,52 @@
+require 'bundler/setup'
+require 'sequel'
+require_relative 'support/benchmark_rails'
+
+DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
+
+DB.create_table(:posts) do
+  primary_key :id
+  column :title, "varchar(255)"
+  column :author, "varchar(255)"
+  column :body, "Text"
+  column :sequence, 'integer(11)'
+  column :age, 'integer(11)'
+  column :legacy_code, "varchar(255)"
+  column :size, "varchar(255)"
+end
+
+class Post < Sequel::Model
+  plugin :validation_helpers
+  def validate
+    super
+    validates_presence :title
+    validates_unique :sequence
+    validates_numeric :age, numericality: { greater_than: 18, less_than: 80 }
+    validates_format /\A[a-zA-Z]+\z/, :legacy_code, :message=> "only allows letters"
+    validates_includes %w(small medium large), :size, :message=> "%{value} is not a valid size"
+  end
+end
+
+Post.create({
+  title: 'RubyBench',
+  author: 'RubyBench',
+  age: 21,
+  sequence: 90,
+  legacy_code: 'letters',
+  size: 'small'
+})
+
+post = Post.new({
+  title: 'RubyBench',
+  author: 'RubyBench',
+  age: 21,
+  sequence: 90,
+  legacy_code: 'letters',
+  size: 'small'
+})
+
+Benchmark.rails("sequel/#{db_adapter}_validations_valid", time: 5) do
+  if post.valid?
+    raise "should be valid"
+  end
+end


### PR DESCRIPTION
I have not included the sequel equivalent of `bm_activerecord_scope_all_with_default_scope.rb` because there is no such concept of `default_scope` in sequel.
Also, sequel doesn't provide the `exclusion` helper, so I removed it from the validations.
