### PR TITLE
Sequel bm: Drop table if already exists when creating new

### DIFF
--- a/sequel/benchmarks/bm_sequel_create_string_columns.rb
+++ b/sequel/benchmarks/bm_sequel_create_string_columns.rb
@@ -6,7 +6,7 @@ DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
 
 COUNT=25
 
-DB.create_table(:users) do
+DB.create_table!(:users) do
   primary_key :id
   COUNT.times do |i|
     String :"column#{i}", size: 255

--- a/sequel/benchmarks/bm_sequel_destroy.rb
+++ b/sequel/benchmarks/bm_sequel_destroy.rb
@@ -4,7 +4,7 @@ require_relative 'support/benchmark_sequel'
 
 DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
 
-DB.create_table(:users) do
+DB.create_table!(:users) do
   primary_key :id
   String :name, size: 255
   String :email, size: 255

--- a/sequel/benchmarks/bm_sequel_finders_find_by_attributes.rb
+++ b/sequel/benchmarks/bm_sequel_finders_find_by_attributes.rb
@@ -4,7 +4,7 @@ require_relative 'support/benchmark_sequel'
 
 DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
 
-DB.create_table(:users) do
+DB.create_table!(:users) do
   primary_key :id
   String :name, size: 255
   String :email, size: 255

--- a/sequel/benchmarks/bm_sequel_finders_first.rb
+++ b/sequel/benchmarks/bm_sequel_finders_first.rb
@@ -4,7 +4,7 @@ require_relative 'support/benchmark_sequel'
 
 DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
 
-DB.create_table(:users) do
+DB.create_table!(:users) do
   primary_key :id
   String :name, size: 255
   String :email, size: 255

--- a/sequel/benchmarks/bm_sequel_save.rb
+++ b/sequel/benchmarks/bm_sequel_save.rb
@@ -4,7 +4,7 @@ require_relative 'support/benchmark_sequel'
 
 DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
 
-DB.create_table(:users) do
+DB.create_table!(:users) do
   primary_key :id
   String :name, size: 255
   String :email, size: 255

--- a/sequel/benchmarks/bm_sequel_scope_all.rb
+++ b/sequel/benchmarks/bm_sequel_scope_all.rb
@@ -4,7 +4,7 @@ require_relative 'support/benchmark_sequel'
 
 DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
 
-DB.create_table(:users) do
+DB.create_table!(:users) do
   primary_key :id
   String :name, size: 255
   String :email, size: 255

--- a/sequel/benchmarks/bm_sequel_scope_where.rb
+++ b/sequel/benchmarks/bm_sequel_scope_where.rb
@@ -4,7 +4,7 @@ require_relative 'support/benchmark_sequel'
 
 DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
 
-DB.create_table(:users) do
+DB.create_table!(:users) do
   primary_key :id
   String :name, size: 255
   String :email, size: 255

--- a/sequel/benchmarks/bm_sequel_validations_invalid.rb
+++ b/sequel/benchmarks/bm_sequel_validations_invalid.rb
@@ -4,7 +4,7 @@ require_relative 'support/benchmark_sequel'
 
 DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
 
-DB.create_table(:posts) do
+DB.create_table!(:posts) do
   primary_key :id
   String :title, size: 255
   String :author, size: 255

--- a/sequel/benchmarks/bm_sequel_validations_valid.rb
+++ b/sequel/benchmarks/bm_sequel_validations_valid.rb
@@ -4,7 +4,7 @@ require_relative 'support/benchmark_sequel'
 
 DB = Sequel.connect(ENV.fetch('DATABASE_URL'))
 
-DB.create_table(:posts) do
+DB.create_table!(:posts) do
   primary_key :id
   String :title, size: 255
   String :author, size: 255


### PR DESCRIPTION
After running sequal benchmark for the first time I have to manually drop table in order to run benchmark again.

In [activerecord benchmarks](https://github.com/ruby-bench/ruby-bench-suite/blob/master/rails/benchmarks/bm_activerecord_scope_all.rb#L10) table with the same name is being dropped before creating new with `force: true` option.

To achieve the same, I replaced [`create_table`](http://sequel.jeremyevans.net/rdoc/files/doc/schema_modification_rdoc.html#label-create_table) with [`create_table!`](http://sequel.jeremyevans.net/rdoc/files/doc/schema_modification_rdoc.html#label-create_table-21) in all sequal benchmarks.