### PR TITLE
Update sequel benchmark

### DIFF
--- a/sequel/benchmarks/bm_sequel_scope_all.rb
+++ b/sequel/benchmarks/bm_sequel_scope_all.rb
@@ -13,8 +13,6 @@ DB.create_table!(:users) do
 end
 
 class User < Sequel::Model
-  self.raise_on_save_failure = true
-  self.set_allowed_columns :name, :email, :created_at, :updated_at
 end
 
 attributes = {
@@ -27,5 +25,5 @@ attributes = {
 end
 
 Benchmark.sequel("sequel/#{db_adapter}_scope_all", time: 5) do
-  User.all.to_a
+  User.all
 end


### PR DESCRIPTION
Model.raise_on_save_failure has been true by default starting in Sequel 4.0.

Model.set_allowed_columns is deprecated and will be moved to a plugin in Sequel 5. There is no reason to set it in this case, since all attributes are allowed.

Model.all returns an array in Sequel, so the to_a is not necessary.

Note that Sequel does not automatically set timestamp values on the timestamp columns, and neither timestamp column has a default.  If you want something more similar to ActiveRecord behavior, you should use the timestamps plugin.  However, the recommended way to handle this when using Sequel is to use database triggers and default column values.