### PR TITLE
Make common benchmark runner to avoid duplication

### DIFF
--- a/liquid_benchmarks/benchmark_liquid.rb
+++ b/liquid_benchmarks/benchmark_liquid.rb
@@ -1,44 +1,12 @@
 require 'benchmark/ips'
 require 'json'
 
+require_relative '../support/benchmark_runner'
+
 module Benchmark
   module Liquid
-    def liquid(label=nil, time: 10, warmup: 5, &block)
-      unless block_given?
-        raise ArgumentError.new, "block should be passed"
-      end
-
-      report = Benchmark.ips(time, warmup, true) do |x|
-        x.report(label) { yield }
-      end
-
-      entry = report.entries.first
-
-      output = {
-        label: label,
-        version: ::Liquid::VERSION.to_s,
-        iterations_per_second: entry.ips,
-        iterations_per_second_standard_deviation: entry.ips_sd,
-        total_allocated_objects_per_iteration: get_total_allocated_objects(&block)
-      }.to_json
-
-      puts output
-    end
-
-    def get_total_allocated_objects
-      if block_given?
-        key =
-          if RUBY_VERSION < '2.2'
-            :total_allocated_object
-          else
-            :total_allocated_objects
-          end
-
-        before = GC.stat[key]
-        yield
-        after = GC.stat[key]
-        after - before
-      end
+    def liquid(label=nil, version: ::Liquid::VERSION.to_s, time: 10, disable_gc: false, warmup: 5, &block)
+      Benchmark::Runner.run(label, version: version, time: time, disable_gc: disable_gc, warmup: warmup, &block)
     end
   end
 

--- a/rails/benchmarks/support/benchmark_rails.rb
+++ b/rails/benchmarks/support/benchmark_rails.rb
@@ -1,53 +1,11 @@
 require 'rails'
-require 'benchmark/ips'
-require 'json'
-
-require_relative 'helpers.rb'
+require_relative '../../../support/benchmark_runner'
+require_relative 'helpers'
 
 module Benchmark
   module Rails
-    def rails(label=nil, time:, disable_gc: true, warmup: 3, &block)
-      unless block_given?
-        raise ArgumentError.new, "block should be passed"
-      end
-
-      if disable_gc
-        GC.disable
-      else
-        GC.enable
-      end
-
-      report = Benchmark.ips(time, warmup, true) do |x|
-        x.report(label) { yield }
-      end
-
-      entry = report.entries.first
-
-      output = {
-        label: label,
-        version: ::Rails.version.to_s,
-        iterations_per_second: entry.ips,
-        iterations_per_second_standard_deviation: entry.stddev_percentage,
-        total_allocated_objects_per_iteration: get_total_allocated_objects(&block)
-      }.to_json
-
-      puts output
-    end
-
-    def get_total_allocated_objects
-      if block_given?
-        key =
-          if RUBY_VERSION < '2.2'
-            :total_allocated_object
-          else
-            :total_allocated_objects
-          end
-
-        before = GC.stat[key]
-        yield
-        after = GC.stat[key]
-        after - before
-      end
+    def rails(label = nil, version: ::Rails.version.to_s, time:, disable_gc: true, warmup: 3, &block)
+      Benchmark::Runner.run(label, version: version, time: time, disable_gc: disable_gc, warmup: warmup, &block)
     end
   end
 

--- a/sequel/benchmarks/support/benchmark_sequel.rb
+++ b/sequel/benchmarks/support/benchmark_sequel.rb
@@ -1,52 +1,13 @@
 require 'benchmark/ips'
 require 'json'
 
+require_relative '../../../support/benchmark_runner'
 require_relative 'helpers.rb'
 
 module Benchmark
   module Sequel
-    def sequel(label=nil, time:, disable_gc: true, warmup: 3, &block)
-      unless block_given?
-        raise ArgumentError.new, "block should be passed"
-      end
-
-      if disable_gc
-        GC.disable
-      else
-        GC.enable
-      end
-
-      report = Benchmark.ips(time, warmup, true) do |x|
-        x.report(label) { yield }
-      end
-
-      entry = report.entries.first
-
-      output = {
-        label: label,
-        version: ::Sequel.version.to_s,
-        iterations_per_second: entry.ips,
-        iterations_per_second_standard_deviation: entry.stddev_percentage,
-        total_allocated_objects_per_iteration: get_total_allocated_objects(&block)
-      }.to_json
-
-      puts output
-    end
-
-    def get_total_allocated_objects
-      if block_given?
-        key =
-          if RUBY_VERSION < '2.2'
-            :total_allocated_object
-          else
-            :total_allocated_objects
-          end
-
-        before = GC.stat[key]
-        yield
-        after = GC.stat[key]
-        after - before
-      end
+    def sequel(label=nil, version: ::Sequel.version.to_s, time:, disable_gc: true, warmup: 3, &block)
+      Benchmark::Runner.run(label, version: version, time: time, disable_gc: disable_gc, warmup: warmup, &block)
     end
   end
 

--- a/support/benchmark_runner.rb
+++ b/support/benchmark_runner.rb
@@ -1,0 +1,55 @@
+require 'benchmark/ips'
+require 'json'
+
+module Benchmark
+  module Runner
+    def self.run(label=nil, version:, time:, disable_gc:, warmup:, &block)
+      unless block_given?
+        raise ArgumentError.new, "You must pass block to run"
+      end
+
+      GC.disable if disable_gc
+
+      ips_result = compute_ips(time, warmup, label, &block)
+      objects_result = compute_objects(&block)
+
+      print_output(ips_result, objects_result, label, version)
+    end
+
+    def self.compute_ips(time, warmup, label, &block)
+      report = Benchmark.ips(time, warmup, true) do |x|
+        x.report(label) { yield }
+      end
+
+      report.entries.first
+    end
+
+    def self.compute_objects(&block)
+      if block_given?
+        key =
+          if RUBY_VERSION < '2.2'
+            :total_allocated_object
+          else
+            :total_allocated_objects
+          end
+
+        before = GC.stat[key]
+        yield
+        after = GC.stat[key]
+        after - before
+      end
+    end
+
+    def self.print_output(ips_result, objects_result, label, version)
+      output = {
+        label: label,
+        version: version,
+        iterations_per_second: ips_result.ips,
+        iterations_per_second_standard_deviation: ips_result.stddev_percentage,
+        total_allocated_objects_per_iteration: objects_result
+      }.to_json
+
+      puts output
+    end
+  end
+end


### PR DESCRIPTION
Benchmark groups `rails`, `sequel` and `liquid` have their own `support/benchmark_*.rb` for running, with exactly the same logic. I made common `benchmark_runner.rb` and placed it in `./support`.

 It is being called from those specific runners `*/support/benchmark_*.rb` with parameters required for certain group of benches.

