### PR TITLE
Add bm_erb_render.rb

### DIFF
--- a/ruby/benchmarks/bm_erb_render.rb
+++ b/ruby/benchmarks/bm_erb_render.rb
@@ -1,0 +1,26 @@
+require 'erb'
+
+data = DATA.read
+max = 1_500_000
+title = "hello world!"
+content = "hello world!\n" * 10
+
+src = "def self.render(title, content); #{ERB.new(data).src}; end"
+mod = Module.new
+mod.instance_eval(src, "(ERB)")
+
+max.times do
+  mod.render(title, content)
+end
+
+__END__
+
+<html>
+  <head> <%= title %> </head>
+  <body>
+    <h1> <%= title %> </h1>
+    <p>
+      <%= content %>
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
I want to add new benchmark for ERB, which is the same as https://github.com/ruby/ruby/blob/85fe3defcc71d40f09a6883b3db2fb5277b3df9c/benchmark/bm_erb_render.rb.

While I guess it's difficult, it would be helpful to backfill bm_erb_render's results for old commits if possible.