### PR TITLE
Don't reuse endpoints in sequel and rails drivers

### DIFF
--- a/rails/benchmarks/driver.rb
+++ b/rails/benchmarks/driver.rb
@@ -136,11 +136,9 @@ class BenchmarkDriver
   end
 
   def endpoint
-    @endpoint ||= begin
-      http = Net::HTTP.new(ENV["API_URL"] || 'rubybench.org', 443)
-      http.use_ssl = true
-      http
-    end
+    http = Net::HTTP.new(ENV["API_URL"] || 'rubybench.org', 443)
+    http.use_ssl = true
+    http
   end
 
   def generate_digest(path, database)

--- a/sequel/benchmarks/driver.rb
+++ b/sequel/benchmarks/driver.rb
@@ -129,11 +129,9 @@ class BenchmarkDriver
   end
 
   def endpoint
-    @endpoint ||= begin
-      http = Net::HTTP.new(ENV["API_URL"] || 'rubybench.org', 443)
-      http.use_ssl = true
-      http
-    end
+    http = Net::HTTP.new(ENV["API_URL"] || 'rubybench.org', 443)
+    http.use_ssl = true
+    http
   end
 
   def generate_digest(path, database)


### PR DESCRIPTION
Fixing sequel and rails drivers same as https://github.com/ruby-bench/ruby-bench-suite/commit/53d5ef396429030f667c0d2e5f1f22702c30e247