### PR TITLE
Fix selection benches to construct string from records

### DIFF
--- a/rails/benchmarks/bm_activerecord_finders_find_by_attributes.rb
+++ b/rails/benchmarks/bm_activerecord_finders_find_by_attributes.rb
@@ -27,5 +27,6 @@ end
 User.create!(name: 'kir', email: 'shatrov@me.com')
 
 Benchmark.rails("activerecord/#{db_adapter}_finders_find_by_attributes", time: 5) do
-  User.find_by_email('shatrov@me.com')
+  user = User.find_by_email('shatrov@me.com')
+  str = "name: #{user.name} email: #{user.email}"
 end

--- a/rails/benchmarks/bm_activerecord_finders_first.rb
+++ b/rails/benchmarks/bm_activerecord_finders_first.rb
@@ -25,5 +25,6 @@ attributes = {
 end
 
 Benchmark.rails("activerecord/#{db_adapter}_finders_first", time: 5) do
-  User.first
+  user = User.first
+  str = "name: #{user.name} email: #{user.email}"
 end

--- a/rails/benchmarks/bm_activerecord_scope_all.rb
+++ b/rails/benchmarks/bm_activerecord_scope_all.rb
@@ -25,5 +25,8 @@ attributes = {
 end
 
 Benchmark.rails("activerecord/#{db_adapter}_scope_all", time: 5) do
-  User.all.to_a
+  str = ""
+  User.all.each do |user|
+    str << "name: #{user.name} email: #{user.email}\n"
+  end
 end

--- a/rails/benchmarks/bm_activerecord_scope_all_with_default_scope.rb
+++ b/rails/benchmarks/bm_activerecord_scope_all_with_default_scope.rb
@@ -33,5 +33,8 @@ admin = true
 end
 
 Benchmark.rails("activerecord/#{db_adapter}_scope_all_with_default_scope", time: 5) do
-  User.all.to_a
+  str = ""
+  User.all.each do |user|
+    str << "name: #{user.name} email: #{user.email}\n"
+  end
 end

--- a/rails/benchmarks/bm_activerecord_scope_where.rb
+++ b/rails/benchmarks/bm_activerecord_scope_where.rb
@@ -25,6 +25,9 @@ class User < ActiveRecord::Base; end
 end
 
 Benchmark.rails("activerecord/#{db_adapter}_scope_where", time: 5) do
-  User.where(name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
-      .where("email LIKE :email", email: "foobar00%@email.com").to_a
+  str = ""
+  User
+    .where(name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
+    .where("email LIKE :email", email: "foobar00%@email.com").to_a
+    .each { |user| str << "name: #{user.name} email: #{user.email}\n" }
 end

--- a/sequel/benchmarks/bm_sequel_finders_find_by_attributes.rb
+++ b/sequel/benchmarks/bm_sequel_finders_find_by_attributes.rb
@@ -29,5 +29,6 @@ end
 User.create(name: 'kir', email: 'shatrov@me.com')
 
 Benchmark.sequel("sequel/#{db_adapter}_finders_find_by_attributes", time: 5) do
-  User.find(email: 'shatrov@me.com')
+  user = User.find(email: 'shatrov@me.com')
+  str = "name: #{user.name} email: #{user.email}"
 end

--- a/sequel/benchmarks/bm_sequel_finders_first.rb
+++ b/sequel/benchmarks/bm_sequel_finders_first.rb
@@ -29,5 +29,6 @@ end
 User.create(name: 'kir', email: 'shatrov@me.com')
 
 Benchmark.sequel("sequel/#{db_adapter}_finders_first", time: 5) do
-  User.first
+  user = User.first
+  str = "name: #{user.name} email: #{user.email}"
 end

--- a/sequel/benchmarks/bm_sequel_scope_all.rb
+++ b/sequel/benchmarks/bm_sequel_scope_all.rb
@@ -25,5 +25,8 @@ attributes = {
 end
 
 Benchmark.sequel("sequel/#{db_adapter}_scope_all", time: 5) do
-  User.all
+  str = ""
+  User.all.each do |user|
+    str << "name: #{user.name} email: #{user.email}\n"
+  end
 end

--- a/sequel/benchmarks/bm_sequel_scope_where.rb
+++ b/sequel/benchmarks/bm_sequel_scope_where.rb
@@ -27,6 +27,9 @@ end
 end
 
 Benchmark.sequel("sequel/#{db_adapter}_scope_where", time: 5) do
-  User.where(name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
-      .where(Sequel.ilike(:email, 'foobar00%@email.com')).to_a
+  str = ""
+  User
+    .where(name: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
+    .where(Sequel.lit('email LIKE ?', 'foobar00%@email.com'))
+    .each { |user| str << "name: #{user.name} email: #{user.email}\n" }
 end


### PR DESCRIPTION
As @SamSaffron suggested:

> This is kind of weak, it is not doing anything with the actual data, so if you defer materialize you automatically get a huge speed boost. We should probably always generate an actual string from these benchmarks to ensure that we materialize stuff, winning on deferred materialization is kind of winning by cheating. Yes, it happens sometimes in the real world but it is a bit of a crutch, why are you even selecting data you are not going to use?

This change will invalidate result data we have so far, but we need this fixed.

Take a closer look at discussion:
https://community.rubybench.org/t/how-can-active-record-be-faster/142