### PR TITLE
Use sequel_pg

### DIFF
--- a/sequel/Gemfile
+++ b/sequel/Gemfile
@@ -16,6 +16,7 @@ else
   gem 'sequel', path: '/sequel'
 end
 
+gem 'sequel_pg', require: 'sequel'
 gem 'activemodel', '~> 4.2.6'
 
 if mysql2_prepared_statements?


### PR DESCRIPTION
We want to use `sequel_pg` for benchmarks with postgres. Since that is what people use mostly in production.

look at discussion:
https://community.rubybench.org/t/how-can-active-record-be-faster/142