### PR TITLE
Fix rails suite

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -23,6 +23,7 @@ if rails_master?
   gem 'turbolinks', github: 'turbolinks/turbolinks-rails', branch: 'master'
 else
   gem 'rails', path: '/rails'
+  gem 'arel', '~> 8.0'
 end
 
 if mysql2_prepared_statements?


### PR DESCRIPTION
This should fix https://github.com/ruby-bench/ruby-bench-web/issues/239.

On bundle install it could not find arel 9.0.0.alpha therefore I've specified latest arel release.