### PR TITLE
Separate mysql2 and pg gems with groups

### DIFF
--- a/support/setup/Gemfile
+++ b/support/setup/Gemfile
@@ -1,5 +1,11 @@
 source "https://rubygems.org"
 
-gem "pg"
-gem "mysql2"
+group :postgres do
+  gem "pg"
+end
+
+group :mysql do
+  gem "mysql2"
+end
+
 gem "activerecord"


### PR DESCRIPTION
We don't need mysql2 gem when running pg suite.