### PR TITLE
Reduce work in raw benchmark

### DIFF
--- a/pg/benchmarks/bm_discourse.rb
+++ b/pg/benchmarks/bm_discourse.rb
@@ -65,10 +65,9 @@ Benchmark.pg("pg/discourse", time: 5) do
   )
 
   # Preload users
-  user_ids = topics.map { |row| row['user_id'] }
-  users = conn.exec("SELECT users.* FROM users WHERE users.id IN (#{user_ids.join(',')})")
+  conn.exec("SELECT users.* FROM users WHERE users.id IN (#{user['id']})")
 
   topics.each_row do |topic|
-    str << "id: #{topic[0]} title: #{topic[3]} created_at: #{Time.parse(topic[1]).iso8601} user: #{username(topic, users)}\n"
+    str << "id: #{topic[0]} title: #{topic[3]} created_at: #{Time.parse(topic[1]).iso8601} user: #{user['username']}\n"
   end
 end


### PR DESCRIPTION
At first I've wanted to do sort of custom preloading of users in order to make fair comparison against ActiveRecord and Sequel.

Though I think it shouldn't be done in raw benchmark. WDYT?