### PR TITLE
Use host names for linked db containers

### DIFF
--- a/pg/benchmarks/pg_suite_runner.rb
+++ b/pg/benchmarks/pg_suite_runner.rb
@@ -9,9 +9,7 @@ require 'digest'
 class PGSuiteRunner
   RAW_URL = 'https://raw.githubusercontent.com/ruby-bench/ruby-bench-suite/master/pg/benchmarks/'
 
-  HOST = ENV['POSTGRES_PORT_5432_TCP_ADDR'] || 'localhost'
-  PORT = ENV['POSTGRES_PORT_5432_TCP_PORT'] || 5432
-  DATABASE_URL = "postgres://postgres@#{HOST}:#{PORT}/rubybench"
+  DATABASE_URL = "postgres://postgres@postgres:5432/rubybench"
 
   def self.run(options)
     new(options).run

--- a/rails/benchmarks/driver.rb
+++ b/rails/benchmarks/driver.rb
@@ -11,14 +11,9 @@ require 'digest'
 
 RAW_URL = 'https://raw.githubusercontent.com/ruby-bench/ruby-bench-suite/master/rails/benchmarks/'
 
-postgres_tcp_addr = ENV['POSTGRES_PORT_5432_TCP_ADDR'] || 'localhost'
-postgres_port = ENV['POSTGRES_PORT_5432_TCP_PORT'] || 5432
-mysql_tcp_addr = ENV['MYSQL_PORT_3306_TCP_ADDR'] || 'localhost'
-mysql_port = ENV['MYSQL_PORT_3306_TCP_PORT'] || 3306
-
 DATABASE_URLS = {
-  psql: "postgres://postgres@#{postgres_tcp_addr}:#{postgres_port}/rubybench",
-  mysql: "mysql2://root@#{mysql_tcp_addr}:#{mysql_port}/rubybench",
+  psql: "postgres://postgres@postgres:5432/rubybench",
+  mysql: "mysql2://root@mysql:3306/rubybench",
 }
 
 class BenchmarkDriver

--- a/sequel/benchmarks/driver.rb
+++ b/sequel/benchmarks/driver.rb
@@ -11,14 +11,9 @@ require 'digest'
 
 RAW_URL = 'https://raw.githubusercontent.com/ruby-bench/ruby-bench-suite/master/sequel/benchmarks/'
 
-postgres_tcp_addr = ENV['POSTGRES_PORT_5432_TCP_ADDR'] || 'localhost'
-postgres_port = ENV['POSTGRES_PORT_5432_TCP_PORT'] || 5432
-mysql_tcp_addr = ENV['MYSQL_PORT_3306_TCP_ADDR'] || 'localhost'
-mysql_port = ENV['MYSQL_PORT_3306_TCP_PORT'] || 3306
-
 DATABASE_URLS = {
-  psql: "postgres://postgres@#{postgres_tcp_addr}:#{postgres_port}/rubybench",
-  mysql: "mysql2://root@#{mysql_tcp_addr}:#{mysql_port}/rubybench",
+  psql: "postgres://postgres@postgres:5432/rubybench",
+  mysql: "mysql2://root@mysql:3306/rubybench",
 }
 
 class BenchmarkDriver


### PR DESCRIPTION
We can use named hosts instead of addresses for DB containers used in docker-compose.

Docker compose setup https://github.com/ruby-bench/ruby-bench-docker/pull/40 should be merged before this one here.