### PR TITLE
Remove deprecated set_allowed_columns method

### DIFF
--- a/sequel/benchmarks/bm_sequel_create_string_columns.rb
+++ b/sequel/benchmarks/bm_sequel_create_string_columns.rb
@@ -17,7 +17,6 @@ end
 
 class User < Sequel::Model
   self.raise_on_save_failure = true
-  self.set_allowed_columns *columns[1..-1]
 end
 
 attributes = {}

--- a/sequel/benchmarks/bm_sequel_destroy.rb
+++ b/sequel/benchmarks/bm_sequel_destroy.rb
@@ -14,7 +14,6 @@ end
 
 class User < Sequel::Model
   self.raise_on_save_failure = true
-  self.set_allowed_columns :name, :email, :created_at, :updated_at
 end
 
 attributes = {

--- a/sequel/benchmarks/bm_sequel_finders_find_by_attributes.rb
+++ b/sequel/benchmarks/bm_sequel_finders_find_by_attributes.rb
@@ -14,7 +14,6 @@ end
 
 class User < Sequel::Model
   self.raise_on_save_failure = true
-  self.set_allowed_columns :name, :email, :created_at, :updated_at
 end
 
 attributes = {

--- a/sequel/benchmarks/bm_sequel_finders_first.rb
+++ b/sequel/benchmarks/bm_sequel_finders_first.rb
@@ -14,7 +14,6 @@ end
 
 class User < Sequel::Model
   self.raise_on_save_failure = true
-  self.set_allowed_columns :name, :email, :created_at, :updated_at
 end
 
 attributes = {

--- a/sequel/benchmarks/bm_sequel_save.rb
+++ b/sequel/benchmarks/bm_sequel_save.rb
@@ -14,7 +14,6 @@ end
 
 class User < Sequel::Model
   self.raise_on_save_failure = true
-  self.set_allowed_columns :name, :email, :created_at, :updated_at
 end
 
 attributes = {

--- a/sequel/benchmarks/bm_sequel_scope_where.rb
+++ b/sequel/benchmarks/bm_sequel_scope_where.rb
@@ -16,7 +16,6 @@ DB.add_index :users, :email, unique: true
 
 class User < Sequel::Model
   self.raise_on_save_failure = true
-  self.set_allowed_columns :name, :email, :created_at, :updated_at
 end
 
 1000.times do |i|

--- a/sequel/benchmarks/bm_sequel_validations_valid.rb
+++ b/sequel/benchmarks/bm_sequel_validations_valid.rb
@@ -26,7 +26,6 @@ class Post < Sequel::Model
     validates_includes %w(small medium large), :size, message: "%{value} is not a valid size"
   end
   self.raise_on_save_failure = true
-  self.set_allowed_columns :title, :author, :body, :sequence, :age, :legacy_code, :size
 end
 
 Post.create({


### PR DESCRIPTION
`set_allowed_columns` is deprecated in Sequel 5.