### PR TITLE
Fix bm_sequel_scope_all benchmark

### DIFF
--- a/sequel/benchmarks/bm_sequel_scope_all.rb
+++ b/sequel/benchmarks/bm_sequel_scope_all.rb
@@ -8,11 +8,12 @@ DB.create_table!(:users) do
   primary_key :id
   String :name, size: 255
   String :email, size: 255
-  DateTime :created_at, null: true
-  DateTime :updated_at, null: true
+  DateTime :created_at, null: false
+  DateTime :updated_at, null: false
 end
 
 class User < Sequel::Model
+  plugin :timestamps, update_on_create: true
 end
 
 attributes = {


### PR DESCRIPTION
As @sgrif pointed out sequel benchmark was inserting nils for timestamps.

Sequel needs :timestamps plugin to support automatic update of timestamps.
@jeremyevans can you please verify this is the correct way to do it with Sequel? Thanks