### PR TITLE
Remove unnecessary dependencies from Gemfiles

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -26,15 +26,8 @@ else
   gem 'rails', path: '/rails'
 end
 
-if mysql2_prepared_statements?
-  # Does not work with < Rails 4.2.5.
-  # See http://github.com/rails/rails/issues/21544.
-  gem 'mysql2', '0.4.6'
-else
-  gem 'mysql2', '0.3.18'
-end
-
 gem 'tzinfo-data'
+gem 'mysql2', '0.4.9'
 gem 'pg', '0.18.1'
 gem 'benchmark-ips', '~> 2.2.0'
 gem 'em-hiredis', '~> 0.3.0'

--- a/sequel/Gemfile
+++ b/sequel/Gemfile
@@ -17,13 +17,7 @@ else
 end
 
 gem 'sequel_pg', require: 'sequel'
-gem 'activemodel', '~> 4.2.6'
 
-if mysql2_prepared_statements?
-  gem 'mysql2', '0.4.2'
-else
-  gem 'mysql2', '0.3.18'
-end
-
+gem 'mysql2', '0.4.9'
 gem 'pg', '0.18.1'
 gem 'benchmark-ips', '~> 2.2.0'


### PR DESCRIPTION
I think we should keep our Gemfiles up to date for running latest Rails and Sequel versions.

Any additional setup for earlier versions we can customize in docker runner script.