### PR TITLE
Make RSS runner extract results correctly from `BenchmarkDriver::Repeater.with_repeat`

### DIFF
--- a/benchmark_driver-output-rubybench/lib/benchmark_driver/output/rubybench.rb
+++ b/benchmark_driver-output-rubybench/lib/benchmark_driver/output/rubybench.rb
@@ -33,8 +33,8 @@ class BenchmarkDriver::Output::Rubybench < BenchmarkDriver::BulkOutput
   # @param [BenchmarkDriver::Metric] metric
   # @param [Hash{ BenchmarkDriver::Context => BenchmarkDriver::Result }] context_result
   def create_benchmark_run(job, metric, context_result)
-    http = Net::HTTP.new(ENV.fetch('API_URL', 'rubybench.org'), 443)
-    http.use_ssl = true
+    http = Net::HTTP.new(ENV.fetch('API_URL', 'rubybench.org'), ENV['API_PORT'] || 443)
+    http.use_ssl = ENV['API_NO_SSL'] != '1'
     request = Net::HTTP::Post.new('/benchmark_runs')
     request.basic_auth(ENV.fetch('API_NAME'), ENV.fetch('API_PASSWORD'))
 

--- a/benchmark_driver-output-rubybench/lib/benchmark_driver/runner/rsskb.rb
+++ b/benchmark_driver-output-rubybench/lib/benchmark_driver/runner/rsskb.rb
@@ -44,11 +44,11 @@ class BenchmarkDriver::Runner::Rsskb
       jobs.each do |job|
         @output.with_job(name: job.name) do
           job.runnable_contexts(@contexts).each do |context|
-            value = BenchmarkDriver::Repeater.with_repeat(config: @config, larger_better: false) do
+            repeat_result = BenchmarkDriver::Repeater.with_repeat(config: @config, larger_better: false) do
               run_benchmark(job, context: context)
             end
             @output.with_context(name: context.name, executable: context.executable, gems: context.gems, prelude: context.prelude) do
-              @output.report(values: { METRIC => value }, loop_count: job.loop_count)
+              @output.report(values: { METRIC => repeat_result.value }, loop_count: job.loop_count)
             end
           end
         end


### PR DESCRIPTION
This commit https://github.com/benchmark-driver/benchmark-driver/commit/b235d963bc56ea272c740a1bf7b3f0d851403425 changed the return value of the `BenchmarkDriver::Repeater.with_repeat` method from a numeric value to a `Struct` instance, so we need to update the RSS runner to reflect the changes introduced by that commit.

cc @k0kubun