### PR TITLE
Stop ruby 2.7 keyword arguments warning

### DIFF
--- a/benchmark_driver-output-rubybench/lib/benchmark_driver/runner/rsskb.rb
+++ b/benchmark_driver-output-rubybench/lib/benchmark_driver/runner/rsskb.rb
@@ -36,7 +36,7 @@ class BenchmarkDriver::Runner::Rsskb
 
     if jobs.any? { |job| job.loop_count.nil? }
       jobs = jobs.map do |job|
-        job.loop_count ? job : Job.new(job.to_h.merge(loop_count: 1))
+        job.loop_count ? job : Job.new(**job.to_h.merge(loop_count: 1))
       end
     end
 

--- a/ruby/benchmark/io_nonblock_noex.rb
+++ b/ruby/benchmark/io_nonblock_noex.rb
@@ -7,8 +7,8 @@ begin
   r, w = IO.pipe
   while i < nr
     i += 1
-    w.write_nonblock(msg, noex)
-    r.read_nonblock(1, buf, noex)
+    w.write_nonblock(msg, **noex)
+    r.read_nonblock(1, buf, **noex)
   end
 rescue ArgumentError # old Rubies
   while i < nr


### PR DESCRIPTION
Ruby 2.7 introduced a deprecation warning related to keyword arguments which caused the benchmarks to produce huge log files (each benchmark run generates a 600+ MB log file) that made the server run out of space. We need to fix the deprecation to be able to continue running the benchmarks.